### PR TITLE
Modify the minimum supported version of go to 1.15

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/OpenFunction/functions-framework-go
 
-go 1.11
+go 1.15
 
 require (
 	github.com/cloudevents/sdk-go/v2 v2.4.1


### PR DESCRIPTION
Modify the minimum supported version of go to 1.15.
That means we will support go functions from 1.15 onwards.
Signed-off-by: laminar <fangtian@yunify.com>