### PR TITLE
Optimization based on OpenFunction Serving feedback (with details inside)

### DIFF
--- a/openfunction-context/types.go
+++ b/openfunction-context/types.go
@@ -1,48 +1,36 @@
 package openfunctioncontext
 
 const (
-	GRPC        Protocol     = "gRPC"
-	HTTP        Protocol     = "HTTP"
-	Dapr        Runtime      = "OpenFuncAsync"
-	Knative     Runtime      = "Knative"
-	DaprBinding ResourceType = "bindings"
-	DaprService ResourceType = "invoke"
-	DaprTopic   ResourceType = "pubsub"
+	OpenFuncAsync   Runtime      = "OpenFuncAsync"
+	Knative         Runtime      = "Knative"
+	OpenFuncBinding ResourceType = "bindings"
+	OpenFuncService ResourceType = "invoke"
+	OpenFuncTopic   ResourceType = "pubsub"
 )
 
 type OpenFunctionContext struct {
-	Name      string      `json:"name"`
-	Version   string      `json:"version"`
-	RequestID string      `json:"request_id,omitempty"`
-	Input     *Input      `json:"input,omitempty"`
-	Outputs   *Outputs    `json:"outputs,omitempty"`
-	Runtime   Runtime     `json:"runtime"`
-	Protocol  Protocol    `json:"protocol,omitempty"`
-	Port      string      `json:"port,omitempty"`
-	State     interface{} `json:"state,omitempty"`
-}
-
-type Outputs struct {
-	Enabled       *bool              `json:"enabled"`
-	OutputObjects map[string]*Output `json:"output_objects,omitempty"`
+	Name      string             `json:"name"`
+	Version   string             `json:"version"`
+	RequestID string             `json:"requestID,omitempty"`
+	Input     Input              `json:"input,omitempty"`
+	Outputs   map[string]*Output `json:"outputs,omitempty"`
+	Runtime   Runtime            `json:"runtime"`
+	Port      string             `json:"port,omitempty"`
+	State     interface{}        `json:"state,omitempty"`
 }
 
 type Input struct {
-	Name    string       `json:"name"`
-	Enabled *bool        `json:"enabled"`
-	Pattern string       `json:"pattern"`
-	InType  ResourceType `json:"in_type,omitempty"`
+	Name   string            `json:"name"`
+	Uri    string            `json:"uri"`
+	Params map[string]string `json:"params,omitempty"`
 }
 
 type Output struct {
-	Pattern string            `json:"pattern"`
-	OutType ResourceType      `json:"out_type,omitempty"`
-	Params  map[string]string `json:"params,omitempty"`
+	Uri    string            `json:"uri"`
+	Params map[string]string `json:"params,omitempty"`
 }
 
 type Runtime string
-
-type OutputMethod string
 
 type Protocol string
 


### PR DESCRIPTION
1. Rename `Dapr` to `OpenFuncAsync`
2. Unify the data input parameters of the function as `in []byte`
3. Remove the switch for input and output
4. Dapr HTTP protocol supported
5. Rename `input.pattern` to `input.uri`, `output.pattern` to `output.uri`
6. Move `input.in_type` into `input.params`, `output.out_type` into `output.params`
7. Rename `gRPC` to `grpc`, `HTTP` to `http`
Signed-off-by: laminar <fangtian@kubesphere.io>