### PR TITLE
fix: use NewClientWithPort() to create the dapr client instead of NewClient().

### DIFF
--- a/openfunction-context/types.go
+++ b/openfunction-context/types.go
@@ -1,26 +1,34 @@
 package openfunctioncontext
 
-import "github.com/dapr/go-sdk/service/common"
+import (
+	daprClient "github.com/dapr/go-sdk/client"
+	"github.com/dapr/go-sdk/service/common"
+)
 
 const (
-	OpenFuncAsync   Runtime      = "OpenFuncAsync"
-	Knative         Runtime      = "Knative"
-	OpenFuncBinding ResourceType = "bindings"
-	OpenFuncTopic   ResourceType = "pubsub"
-	Success         ReturnCode   = 200
-	InternalError   ReturnCode   = 500
+	OpenFuncAsync            Runtime      = "OpenFuncAsync"
+	Knative                  Runtime      = "Knative"
+	OpenFuncBinding          ResourceType = "bindings"
+	OpenFuncTopic            ResourceType = "pubsub"
+	Success                  ReturnCode   = 200
+	InternalError            ReturnCode   = 500
+	DefaultOpenFuncAsyncPort              = "50001"
+	DefaultKnaitvePort                    = "8080"
+	DefaultDaprClientPort                 = "44543"
 )
 
 type OpenFunctionContext struct {
-	Name      string             `json:"name"`
-	Version   string             `json:"version"`
-	RequestID string             `json:"requestID,omitempty"`
-	Inputs    map[string]*Input  `json:"inputs,omitempty"`
-	Outputs   map[string]*Output `json:"outputs,omitempty"`
-	Runtime   Runtime            `json:"runtime"`
-	Port      string             `json:"port,omitempty"`
-	State     interface{}        `json:"state,omitempty"`
-	Event     *EventMetadata     `json:"event,omitempty"`
+	Name       string             `json:"name"`
+	Version    string             `json:"version"`
+	RequestID  string             `json:"requestID,omitempty"`
+	Inputs     map[string]*Input  `json:"inputs,omitempty"`
+	Outputs    map[string]*Output `json:"outputs,omitempty"`
+	Runtime    Runtime            `json:"runtime"`
+	Port       string             `json:"port,omitempty"`
+	ClientPort string             `json:"clientPort,omitempty"`
+	State      interface{}        `json:"state,omitempty"`
+	Event      *EventMetadata     `json:"event,omitempty"`
+	DaprClient daprClient.Client
 }
 
 type EventMetadata struct {


### PR DESCRIPTION
We perform `client.Close()` to close all connections when the dapr client has an exception to interact with the target service.

I have elevated this dapr client to the functionframeworks pkg, which makes it a global variable that can be reused and will only be recreated if the function throws an exception.

In addition, the dapr client created with `NewClient()` will remain in the `the client connection is closing` state, even if the target service is restored.

```shell
== APP == 2021/12/28 14:47:57 binding - Data: Received
== APP == dapr client initializing for: 127.0.0.1:42327
== APP == 2021/12/28 14:47:59 binding - Data: Received
== APP == 2021/12/28 14:48:01 binding - Data: Received
== APP == 2021/12/28 14:48:03 binding - Data: Received
== APP == 2021/12/28 14:48:03 Error: error invoking binding echo/create: rpc error: code = Internal desc = error when invoke output binding echo: Post "http://localhost:7489/echo": dial tcp 127.0.0.1:7489: connect: connection refused
== APP == 2021/12/28 14:48:05 binding - Data: Received
== APP == 2021/12/28 14:48:05 Error: error invoking binding echo/create: rpc error: code = Canceled desc = grpc: the client connection is closing
== APP == 2021/12/28 14:48:07 binding - Data: Received
== APP == 2021/12/28 14:48:07 Error: error invoking binding echo/create: rpc error: code = Canceled desc = grpc: the client connection is closing
== APP == 2021/12/28 14:48:09 binding - Data: Received
== APP == 2021/12/28 14:48:09 Error: error invoking binding echo/create: rpc error: code = Canceled desc = grpc: the client connection is closing
```

Instead, the dapr client created with `NewClientWithPort()` will be restored as the peer service is restored.
```shell
== APP == 2021/12/28 16:55:19 binding - Data: Received
== APP == 2021/12/28 16:55:19 Error: error invoking binding echo/create: rpc error: code = Internal desc = error when invoke output binding echo: Post "http://localhost:7489/echo": dial tcp 127.0.0.1:7489: connect: connection refused
== APP == 2021/12/28 16:55:21 binding - Data: Received
== APP == 2021/12/28 16:55:21 Error: error invoking binding echo/create: rpc error: code = Internal desc = error when invoke output binding echo: Post "http://localhost:7489/echo": dial tcp 127.0.0.1:7489: connect: connection refused
== APP == 2021/12/28 16:55:23 binding - Data: Received
== APP == 2021/12/28 16:55:23 Error: error invoking binding echo/create: rpc error: code = Internal desc = error when invoke output binding echo: Post "http://localhost:7489/echo": dial tcp 127.0.0.1:7489: connect: connection refused
== APP == 2021/12/28 16:55:25 binding - Data: Received
== APP == 2021/12/28 16:55:27 binding - Data: Received
== APP == 2021/12/28 16:55:29 binding - Data: Received
== APP == 2021/12/28 16:55:31 binding - Data: Received
== APP == 2021/12/28 16:55:31 Error: error invoking binding echo/create: rpc error: code = Internal desc = error when invoke output binding echo: Post "http://localhost:7489/echo": dial tcp 127.0.0.1:7489: connect: connection refused
== APP == 2021/12/28 16:55:33 binding - Data: Received
== APP == 2021/12/28 16:55:33 Error: error invoking binding echo/create: rpc error: code = Internal desc = error when invoke output binding echo: Post "http://localhost:7489/echo": dial tcp 127.0.0.1:7489: connect: connection refused
== APP == 2021/12/28 16:55:35 binding - Data: Received
== APP == 2021/12/28 16:55:35 Error: error invoking binding echo/create: rpc error: code = Internal desc = error when invoke output binding echo: Post "http://localhost:7489/echo": dial tcp 127.0.0.1:7489: connect: connection refused
== APP == 2021/12/28 16:55:37 binding - Data: Received
== APP == 2021/12/28 16:55:37 Error: error invoking binding echo/create: rpc error: code = Internal desc = error when invoke output binding echo: Post "http://localhost:7489/echo": dial tcp 127.0.0.1:7489: connect: connection refused
```
Signed-off-by: laminar <fangtian@kubesphere.io>