### PR TITLE
add support for running dapr app on knative runtime

### DIFF
--- a/context/types.go
+++ b/context/types.go
@@ -14,14 +14,13 @@ const (
 	Knative             Runtime      = "Knative"
 	OpenFuncBinding     ResourceType = "bindings"
 	OpenFuncTopic       ResourceType = "pubsub"
-	Success             ReturnCode   = 200
-	InternalError       ReturnCode   = 500
+	Success                          = 200
+	InternalError                    = 500
 	defaultPort                      = "8080"
 	daprSidecarGRPCPort              = "50001"
 )
 
 type Runtime string
-type ReturnCode int
 type ResourceType string
 
 type Context struct {
@@ -52,8 +51,8 @@ type EventMetadata struct {
 }
 
 type SyncRequestMetadata struct {
-	ResponseWriter http.ResponseWriter `json:"responseWriter,omitempty"`
-	Request        *http.Request       `json:"request,omitempty"`
+	ResponseWriter *http.ResponseWriter `json:"responseWriter,omitempty"`
+	Request        *http.Request        `json:"request,omitempty"`
 }
 
 type Input struct {
@@ -72,7 +71,7 @@ type Output struct {
 }
 
 type Out struct {
-	Code     ReturnCode        `json:"code"`
+	Code     int               `json:"code"`
 	Data     []byte            `json:"data,omitempty"`
 	Metadata map[string]string `json:"metadata,omitempty"`
 	Error    error             `json:"error,omitempty"`


### PR DESCRIPTION
```shell
~# curl -v -d '{"message":"msg from knative runtime"}' -H "Content-Type: application/json" -X POST http://openfunction-function.default.192.168.0.2.sslip.io
Note: Unnecessary use of -X or --request, POST is already inferred.
* Rebuilt URL to: http://openfunction-function.default.192.168.0.2.sslip.io/
*   Trying 192.168.0.2...
* TCP_NODELAY set
* Connected to openfunction-function.default.192.168.0.2.sslip.io (192.168.0.2) port 80 (#0)
> POST / HTTP/1.1
> Host: openfunction-function.default.192.168.0.2.sslip.io
> User-Agent: curl/7.58.0
> Accept: */*
> Content-Type: application/json
> Content-Length: 20
>
* upload completely sent off: 20 out of 20 bytes
< HTTP/1.1 200 OK
< content-length: 0
< date: Fri, 14 Jan 2022 07:51:51 GMT
< x-openfunction-status: success
< x-envoy-upstream-service-time: 4252
< server: envoy
<
* Connection #0 to host openfunction-function.default.192.168.0.2.sslip.io left intact
```

logs from output target:
```shell
message from Kafka '{msg from knative runtime}'
```


Signed-off-by: laminar <fangtian@kubesphere.io>