### PR TITLE
Add innerEvent for carrying events in the functions-framework

### DIFF
--- a/context/context.go
+++ b/context/context.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"reflect"
 	"strconv"
+	"strings"
 	"sync"
 
 	cloudevents "github.com/cloudevents/sdk-go/v2"
@@ -19,7 +20,18 @@ import (
 )
 
 var (
-	clientGRPCPort string
+	clientGRPCPort         string
+	bindingQueueComponents = map[string]bool{
+		"bindings.kafka":                  true,
+		"bindings.rabbitmq":               true,
+		"bindings.aws.sqs":                true,
+		"bindings.aws.kinesis":            true,
+		"bindings.gcp.pubsub":             true,
+		"bindings.azure.eventgrid":        true,
+		"bindings.azure.eventhubs":        true,
+		"bindings.azure.servicebusqueues": true,
+		"bindings.azure.storagequeues":    true,
+	}
 )
 
 const (
@@ -41,6 +53,7 @@ const (
 	KubernetesMode                            = "kubernetes"
 	SelfHostMode                              = "self-host"
 	TestModeOn                                = "on"
+	innerEventTypePrefix                      = "io.openfunction.function"
 )
 
 type Runtime string
@@ -50,6 +63,9 @@ type RuntimeContext interface {
 
 	// GetName returns the function's name.
 	GetName() string
+
+	// GetMode returns the operating environment mode of the function.
+	GetMode() string
 
 	// GetContext returns the pointer of raw OpenFunction FunctionContext object.
 	GetContext() *FunctionContext
@@ -97,12 +113,6 @@ type RuntimeContext interface {
 	// SetEvent sets the name of the input source and the native event when an event request is received.
 	SetEvent(inputName string, event interface{})
 
-	// SetEventMetadata sets the metadata of the EventRequest.
-	SetEventMetadata(key string, value string)
-
-	// GetEventMetadata returns the metadata of the EventRequest.
-	GetEventMetadata() map[string]string
-
 	// GetInputs returns the mapping relationship of *Input.
 	GetInputs() map[string]*Input
 
@@ -120,6 +130,9 @@ type RuntimeContext interface {
 
 	// GetCloudEvent returns the pointer of v2.Event.
 	GetCloudEvent() *cloudevents.Event
+
+	// GetInnerEvent returns the InnerEvent.
+	GetInnerEvent() InnerEvent
 
 	// WithOut adds the FunctionOut object to the RuntimeContext.
 	WithOut(out *FunctionOut) RuntimeContext
@@ -159,6 +172,9 @@ type Context interface {
 
 	// GetCloudEvent returns the pointer of v2.Event.
 	GetCloudEvent() *cloudevents.Event
+
+	// GetInnerEvent returns the InnerEvent.
+	GetInnerEvent() InnerEvent
 }
 
 type Out interface {
@@ -230,7 +246,7 @@ type EventRequest struct {
 	BindingEvent *common.BindingEvent `json:"bindingEvent,omitempty"`
 	TopicEvent   *common.TopicEvent   `json:"topicEvent,omitempty"`
 	CloudEvent   *cloudevents.Event   `json:"cloudEventnt,omitempty"`
-	Metadata     map[string]string    `json:"metadata,omitempty"`
+	innerEvent   InnerEvent
 }
 
 type SyncRequest struct {
@@ -239,18 +255,20 @@ type SyncRequest struct {
 }
 
 type Input struct {
-	Uri       string            `json:"uri,omitempty"`
-	Component string            `json:"component,omitempty"`
-	Type      ResourceType      `json:"type"`
-	Metadata  map[string]string `json:"metadata,omitempty"`
+	Uri           string            `json:"uri,omitempty"`
+	Component     string            `json:"component"`
+	ComponentType string            `json:"componentType"`
+	Type          ResourceType      `json:"type"`
+	Metadata      map[string]string `json:"metadata,omitempty"`
 }
 
 type Output struct {
-	Uri       string            `json:"uri,omitempty"`
-	Component string            `json:"component,omitempty"`
-	Type      ResourceType      `json:"type"`
-	Metadata  map[string]string `json:"metadata,omitempty"`
-	Operation string            `json:"operation,omitempty"`
+	Uri           string            `json:"uri,omitempty"`
+	Component     string            `json:"component"`
+	ComponentType string            `json:"componentType"`
+	Type          ResourceType      `json:"type"`
+	Metadata      map[string]string `json:"metadata,omitempty"`
+	Operation     string            `json:"operation,omitempty"`
 }
 
 type FunctionOut struct {
@@ -310,6 +328,8 @@ func (ctx *FunctionContext) Send(outputName string, data []byte) ([]byte, error)
 	var err error
 	var output *Output
 	var response *dapr.BindingEvent
+	var payload interface{}
+	var payloadBytes []byte
 
 	if v, ok := ctx.Outputs[outputName]; ok {
 		output = v
@@ -317,14 +337,25 @@ func (ctx *FunctionContext) Send(outputName string, data []byte) ([]byte, error)
 		return nil, fmt.Errorf("output %s not found", outputName)
 	}
 
+	payload = data
+	payloadBytes = data
+
+	if traceable(output.ComponentType) {
+		ie := NewInnerEvent(ctx)
+		ie.MergeMetadata(ctx.GetInnerEvent())
+		ie.SetUserData(data)
+		payload = ie.GetCloudEvent()
+		payloadBytes = ie.GetCloudEventJSON()
+	}
+
 	switch output.Type {
 	case OpenFuncTopic:
-		err = ctx.daprClient.PublishEvent(context.Background(), output.Component, output.Uri, data)
+		err = ctx.daprClient.PublishEvent(context.Background(), output.Component, output.Uri, payload)
 	case OpenFuncBinding:
 		in := &dapr.InvokeBindingRequest{
 			Name:      output.Component,
 			Operation: output.Operation,
-			Data:      data,
+			Data:      payloadBytes,
 			Metadata:  output.Metadata,
 		}
 		response, err = ctx.daprClient.InvokeBinding(context.Background(), in)
@@ -437,32 +468,32 @@ func (ctx *FunctionContext) SetSyncRequest(w http.ResponseWriter, r *http.Reques
 }
 
 func (ctx *FunctionContext) SetEvent(inputName string, event interface{}) {
-	ctx.mu.Lock()
-	defer ctx.mu.Unlock()
 	switch t := event.(type) {
 	case *common.BindingEvent:
-		ctx.Event.BindingEvent = event.(*common.BindingEvent)
+		be := event.(*common.BindingEvent)
+		ie := convertEvent(ctx, inputName, be.Data)
+		ctx.setEvent(inputName, be, nil, nil, ie)
 	case *common.TopicEvent:
-		ctx.Event.TopicEvent = event.(*common.TopicEvent)
+		te := event.(*common.TopicEvent)
+		ie := convertEvent(ctx, inputName, te.Data)
+		ctx.setEvent(inputName, nil, te, nil, ie)
 	case *cloudevents.Event:
-		ctx.Event.CloudEvent = event.(*cloudevents.Event)
+		ce := event.(*cloudevents.Event)
+		ie := convertEvent(ctx, inputName, ce.Data())
+		ctx.setEvent(inputName, nil, nil, ce, ie)
 	default:
 		klog.Errorf("failed to resolve event type: %v", t)
 	}
-	ctx.Event.InputName = inputName
 }
 
-func (ctx *FunctionContext) SetEventMetadata(key string, value string) {
+func (ctx *FunctionContext) setEvent(name string, be *common.BindingEvent, te *common.TopicEvent, ce *cloudevents.Event, ie InnerEvent) {
 	ctx.mu.Lock()
 	defer ctx.mu.Unlock()
-	if ctx.Event.Metadata == nil {
-		ctx.Event.Metadata = map[string]string{}
-	}
-	ctx.Event.Metadata[key] = value
-}
-
-func (ctx *FunctionContext) GetEventMetadata() map[string]string {
-	return ctx.Event.Metadata
+	ctx.Event.InputName = name
+	ctx.Event.BindingEvent = be
+	ctx.Event.TopicEvent = te
+	ctx.Event.CloudEvent = ce
+	ctx.Event.innerEvent = ie
 }
 
 func (ctx *FunctionContext) GetName() string {
@@ -503,6 +534,10 @@ func (ctx *FunctionContext) GetTopicEvent() *common.TopicEvent {
 
 func (ctx *FunctionContext) GetCloudEvent() *cloudevents.Event {
 	return ctx.Event.CloudEvent
+}
+
+func (ctx *FunctionContext) GetInnerEvent() InnerEvent {
+	return ctx.Event.innerEvent
 }
 
 func (ctx *FunctionContext) GetPluginsTracingCfg() TracingConfig {
@@ -735,4 +770,17 @@ func parseContext() (*FunctionContext, error) {
 
 func NewFunctionOut() *FunctionOut {
 	return &FunctionOut{}
+}
+
+// Convert queue binding event into cloud event format to add tracing metadata in the cloud event context.
+func traceable(t string) bool {
+
+	// All events sent to dapr pubsub components need to be encapsulated
+	if strings.HasPrefix(t, "pubsub") {
+		return true
+	}
+
+	// For dapr binding components, let the mapping conditions of the bindingQueueComponents
+	// determine if the tracing metadata can be added.
+	return bindingQueueComponents[t]
 }

--- a/context/innerevent.go
+++ b/context/innerevent.go
@@ -1,0 +1,205 @@
+package context
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"sync"
+	"time"
+
+	"k8s.io/klog/v2"
+
+	cloudevents "github.com/cloudevents/sdk-go/v2"
+	"github.com/google/uuid"
+)
+
+type InnerEvent interface {
+
+	// SetMetadata sets the metadata in innerEventData.
+	SetMetadata(key string, value string)
+
+	// GetMetadata returns the metadata in innerEventData.
+	GetMetadata() map[string]string
+
+	// SetUserData sets the userData in innerEventData.
+	SetUserData(data interface{})
+
+	// GetUserData returns the userData in innerEventData.
+	GetUserData() interface{}
+
+	// GetCloudEvent returns the cloudevent object in innerEvent.
+	GetCloudEvent() cloudevents.Event
+
+	// MergeMetadata merges the metadata of the incoming event into the new event.
+	MergeMetadata(event InnerEvent)
+
+	// Clone clones a new innerEvent.
+	Clone(event *cloudevents.Event)
+
+	// GetCloudEventJSON returns the cloudevent in json format.
+	GetCloudEventJSON() []byte
+
+	// SetSubject sets the subject of the cloudevent in the innerEvent.
+	SetSubject(s string)
+}
+
+type innerEvent struct {
+	mu         sync.Mutex
+	cloudevent *cloudevents.Event
+	data       *innerEventData
+}
+
+type innerEventData struct {
+	Metadata map[string]string `json:"metadata,omitempty"`
+	UserData interface{}       `json:"userData,omitempty"`
+}
+
+func NewInnerEvent(ctx RuntimeContext) InnerEvent {
+	ie := &innerEvent{}
+	ce := cloudevents.NewEvent()
+	ie.cloudevent = &ce
+	ie.data = &innerEventData{}
+	ie.data.Metadata = map[string]string{}
+	ie.initCloudEventHeaders(ctx)
+	return ie
+}
+
+func (inner *innerEvent) SetMetadata(key string, value string) {
+	inner.mu.Lock()
+	defer func() {
+		inner.save()
+		inner.mu.Unlock()
+	}()
+	inner.data.Metadata[key] = value
+}
+
+func (inner *innerEvent) GetMetadata() map[string]string {
+	inner.mu.Lock()
+	defer inner.mu.Unlock()
+	return inner.data.Metadata
+}
+
+func (inner *innerEvent) SetUserData(data interface{}) {
+	inner.mu.Lock()
+	defer func() {
+		inner.save()
+		inner.mu.Unlock()
+	}()
+	inner.data.UserData = data
+}
+
+func (inner *innerEvent) SetSubject(s string) {
+	inner.mu.Lock()
+	defer inner.mu.Unlock()
+	inner.cloudevent.SetSubject(s)
+}
+
+func (inner *innerEvent) GetUserData() interface{} {
+	return inner.data.UserData
+}
+
+func (inner *innerEvent) initCloudEventHeaders(ctx RuntimeContext) {
+	var source string
+	var t string
+
+	if ctx.GetMode() == KubernetesMode {
+		source = fmt.Sprintf("%s/%s", ctx.GetPodNamespace(), ctx.GetName())
+		t = fmt.Sprintf("%s.%s.%s", innerEventTypePrefix, ctx.GetPodNamespace(), ctx.GetName())
+
+	} else {
+		source = ctx.GetName()
+		t = fmt.Sprintf("%s.%s", innerEventTypePrefix, ctx.GetName())
+	}
+
+	inner.cloudevent.SetID(uuid.New().String())
+	inner.cloudevent.SetTime(time.Now())
+	inner.cloudevent.SetSource(source)
+	inner.cloudevent.SetType(t)
+	inner.cloudevent.SetDataContentType(cloudevents.ApplicationJSON)
+}
+
+func (inner *innerEvent) GetCloudEvent() cloudevents.Event {
+	return *inner.cloudevent
+}
+
+func (inner *innerEvent) GetCloudEventJSON() []byte {
+	ceBytes, err := json.Marshal(*inner.cloudevent)
+	if err != nil {
+		return nil
+	}
+	return ceBytes
+}
+
+func (inner *innerEvent) MergeMetadata(event InnerEvent) {
+	if event == nil || event.GetMetadata() == nil {
+		return
+	}
+
+	inner.mu.Lock()
+	defer func() {
+		inner.save()
+		inner.mu.Unlock()
+	}()
+
+	for k, v := range event.GetMetadata() {
+		inner.data.Metadata[k] = v
+	}
+}
+
+func (inner *innerEvent) Clone(event *cloudevents.Event) {
+	inner.mu.Lock()
+	defer func() {
+		inner.save()
+		inner.mu.Unlock()
+	}()
+
+	inner.cloudevent = event
+
+	d := &innerEventData{}
+	if event.Data() != nil {
+		if err := event.DataAs(d); err == nil {
+			inner.data.Metadata = d.Metadata
+			inner.data.UserData = d.UserData
+		} else {
+			inner.data.UserData = event.Data()
+		}
+	}
+}
+
+func (inner *innerEvent) save() {
+	if inner.cloudevent == nil || (inner.data != nil && reflect.DeepEqual(inner.data.Metadata, map[string]string{}) && inner.data.UserData == nil) {
+		fmt.Println(inner.data.UserData)
+		return
+	}
+
+	if err := inner.cloudevent.SetData(cloudevents.ApplicationJSON, *inner.data); err != nil {
+		klog.Errorf("failed to set cloudevent data: %v\n", err)
+	}
+}
+
+func convertEvent(ctx RuntimeContext, inputName string, data interface{}) InnerEvent {
+	inner := NewInnerEvent(ctx)
+	ce := &cloudevents.Event{}
+	if data != nil {
+		switch data := data.(type) {
+		case []byte:
+			if err := json.Unmarshal(data, ce); err != nil {
+				inner.SetSubject(inputName)
+				inner.SetUserData(data)
+				return inner
+			} else {
+				inner.Clone(ce)
+				return inner
+			}
+		case cloudevents.Event:
+			inner.Clone(&data)
+			return inner
+		default:
+			inner.SetSubject(inputName)
+			inner.SetUserData(data)
+			return inner
+		}
+	}
+	inner.SetSubject(inputName)
+	return inner
+}

--- a/context/innerevent_test.go
+++ b/context/innerevent_test.go
@@ -1,0 +1,212 @@
+package context
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/dapr/go-sdk/service/common"
+)
+
+var funcCtx = `{
+  "name": "function-test",
+  "version": "v1.0.0",
+  "runtime": "Async",
+  "port": "12345",
+  "inputs": {
+    "cron": {
+      "uri": "cron_input",
+      "type": "bindings",
+      "component": "cron_input"
+    },
+    "eventbus": {
+      "uri": "default",
+      "type": "pubsub",
+      "component": "nats_eventbus"
+    }
+  },
+  "outputs": {
+    "echo": {
+      "uri": "echo",
+      "operation": "create",
+      "component": "echo",
+      "componentType": "bindings.kafka",
+      "metadata": {
+        "path": "echo",
+        "Content-Type": "application/json; charset=utf-8"
+      },
+      "type": "bindings"
+    },
+    "target": {
+      "uri": "sample",
+      "operation": "create",
+      "component": "kafka-server",
+      "componentType": "pubsub.kafka",
+      "type": "pubsub"
+    },
+    "target2": {
+      "uri": "cron_output",
+      "component": "cron_output",
+      "componentType": "bindings.cron",
+      "type": "bindings"
+    }
+  }
+}`
+
+// TestInnerEvent tests and verifies the function that parses the function FunctionContext
+func TestInnerEvent(t *testing.T) {
+
+	var ctx RuntimeContext
+
+	if err := os.Setenv(PodNameEnvName, "test-pod"); err != nil {
+		t.Fatal("Error set pod name env")
+	}
+
+	if err := os.Setenv(PodNamespaceEnvName, "test"); err != nil {
+		t.Fatal("Error set pod namespace env")
+	}
+
+	if err := os.Setenv(FunctionContextEnvName, funcCtx); err != nil {
+		t.Fatal("Error set function context env")
+
+	}
+
+	ctx, err := GetRuntimeContext()
+	if err != nil {
+		t.Fatalf("Error parse function context: %v", err)
+	}
+
+	data := map[string]string{
+		"foo1": "bar1",
+	}
+
+	byteData, _ := json.Marshal(data)
+
+	ie := NewInnerEvent(ctx)
+	ie.SetMetadata("k2", "v2")
+	ie.SetUserData(data)
+
+	// test bindingEvent
+	be1 := &common.BindingEvent{
+		Data: byteData,
+	}
+	eventTest(t, ctx, be1, byteData)
+
+	be2 := &common.BindingEvent{
+		Data: ie.GetCloudEventJSON(),
+	}
+	eventTest(t, ctx, be2, byteData)
+
+	// test topicEvent
+	te1 := &common.TopicEvent{
+		Data: byteData,
+	}
+	eventTest(t, ctx, te1, byteData)
+
+	te2 := &common.TopicEvent{
+		Data: ie.GetCloudEvent(),
+	}
+	eventTest(t, ctx, te2, byteData)
+
+	// test if we need wrap user data
+	outputs := ctx.GetOutputs()
+	if outputs == nil {
+		t.Fatal("Error get outputs in context")
+	}
+
+	if output, exist := outputs["target"]; exist && output != nil && traceable(output.ComponentType) {
+
+	} else {
+		t.Fatal("Error determining whether user data needs to be wrapped")
+	}
+
+	if output, exist := outputs["target2"]; exist && output != nil && !traceable(output.ComponentType) {
+
+	} else {
+		t.Fatal("Error determining whether user data needs to be wrapped")
+	}
+}
+
+func eventTest(t *testing.T, ctx RuntimeContext, event interface{}, target []byte) {
+
+	// receive test
+	ctx.SetEvent("cron", event)
+	ie := ctx.GetInnerEvent()
+	if !bytes.Equal(convertToByte(ie.GetUserData()), target) {
+		t.Fatal("Error get user data in innerEvent")
+	}
+	ie.SetMetadata("k1", "v1")
+
+	// send test
+
+	data := map[string]string{
+		"foo2": "bar2",
+	}
+
+	ie2 := NewInnerEvent(ctx)
+	ie2.MergeMetadata(ctx.GetInnerEvent())
+	ie2.SetUserData(data)
+	if ie2.GetMetadata() != nil {
+		if v, exist := ie2.GetMetadata()["k1"]; exist && v == "v1" {
+
+		} else {
+			t.Fatal("Error set inner event metadata")
+		}
+	} else {
+		t.Fatal("Error set inner event metadata")
+	}
+
+	udInEvent := map[string]string{}
+	if ie2.GetUserData() != nil {
+		ud := ie2.GetUserData()
+		switch ud := ud.(type) {
+		case []byte:
+			if err := json.Unmarshal(ud, &udInEvent); err != nil {
+				t.Fatal("Error unmarshal user data in inner event")
+			}
+			if v, exist := udInEvent["foo2"]; exist && v == "bar2" {
+
+			} else {
+				t.Fatal("Error set inner event userdata")
+			}
+		}
+	} else {
+		t.Fatal("Error set inner event userdata")
+	}
+
+	// cloudevent test
+	ce := ie2.GetCloudEvent()
+	if ce.Data() == nil {
+		t.Fatal("Error set inner event cloudevent")
+	}
+
+	ieData := &innerEventData{}
+	if err := ce.DataAs(ieData); err != nil {
+		t.Fatalf("Error save inner event data: %v", err)
+	}
+
+	ud := map[string]string{}
+	udByte, _ := json.Marshal(ieData.UserData)
+	if err := json.Unmarshal(udByte, &ud); err != nil {
+		t.Fatal("Error unmarshal user data in inner event")
+	}
+
+	if v, exist := ud["foo2"]; exist && v == "bar2" {
+
+	} else {
+		t.Fatal("Error save inner event userdata")
+	}
+
+}
+
+func convertToByte(data interface{}) []byte {
+	if d, ok := data.([]byte); ok {
+		return d
+	}
+	if d, err := json.Marshal(data); err != nil {
+		return nil
+	} else {
+		return d
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/dapr/go-sdk v1.3.1
 	github.com/fatih/structs v1.1.0
 	github.com/golang/protobuf v1.5.2
+	github.com/google/uuid v1.3.0
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.7.0
 	google.golang.org/grpc v1.40.0


### PR DESCRIPTION
The changes are as follows:

1. a new structure called `innerEvent` has been added for passing events from dapr components inside the functions-framework
2. `innerEvent` has been wrapped and unwrapped in the section that receives events from dapr components and sends events to dapr components
3. for data that needs to be passed in the OpenFunction function, we use `innerEventData` to encapsulate it, so that the custom information other than user data can be passed via `innerEventData.Metadata`

Signed-off-by: laminar <fangtian@kubesphere.io>