### PR TITLE
adjust the structure of Input and Output

### DIFF
--- a/context/innerevent_test.go
+++ b/context/innerevent_test.go
@@ -17,39 +17,36 @@ var funcCtx = `{
   "inputs": {
     "cron": {
       "uri": "cron_input",
-      "type": "bindings",
-      "component": "cron_input"
+      "componentName": "cron_input",
+      "componentType": "bindings.cron"
     },
     "eventbus": {
       "uri": "default",
-      "type": "pubsub",
-      "component": "nats_eventbus"
+      "componentName": "nats_eventbus",
+      "componentType": "pubsub.natsstreaming"
     }
   },
   "outputs": {
     "echo": {
       "uri": "echo",
       "operation": "create",
-      "component": "echo",
+      "componentName": "echo",
       "componentType": "bindings.kafka",
       "metadata": {
         "path": "echo",
         "Content-Type": "application/json; charset=utf-8"
-      },
-      "type": "bindings"
+      }
     },
     "target": {
       "uri": "sample",
       "operation": "create",
-      "component": "kafka-server",
-      "componentType": "pubsub.kafka",
-      "type": "pubsub"
+      "componentName": "kafka-server",
+      "componentType": "pubsub.kafka"
     },
     "target2": {
       "uri": "cron_output",
-      "component": "cron_output",
-      "componentType": "bindings.cron",
-      "type": "bindings"
+      "componentName": "cron_output",
+      "componentType": "bindings.cron"
     }
   }
 }`

--- a/framework/framework_test.go
+++ b/framework/framework_test.go
@@ -176,8 +176,8 @@ func TestAsyncBindingsFunction(t *testing.T) {
   "inputs": {
     "cron": {
       "uri": "test",
-      "type": "bindings",
-      "component": "test"
+      "componentName": "test",
+      "componentType": "bindings.Kafka"
     }
   }
 }`
@@ -259,8 +259,8 @@ func TestAsyncPubsubTopic(t *testing.T) {
   "inputs": {
     "sub": {
       "uri": "my_topic",
-      "type": "pubsub",
-      "component": "msg"
+      "componentName": "msg",
+      "componentType": "pubsub.kafka"
     }
   }
 }`

--- a/runtime/async/async.go
+++ b/runtime/async/async.go
@@ -90,9 +90,9 @@ func (r *Runtime) RegisterOpenFunction(
 		// Serving function with inputs
 		if ctx.HasInputs() {
 			for name, input := range ctx.GetInputs() {
-				switch input.Type {
+				switch input.GetType() {
 				case ofctx.OpenFuncBinding:
-					input.Uri = input.Component
+					input.Uri = input.ComponentName
 					funcErr = r.handler.AddBindingInvocationHandler(input.Uri, func(c context.Context, in *dapr.BindingEvent) (out []byte, err error) {
 						rm := runtime.NewRuntimeManager(ctx, prePlugins, postPlugins)
 						rm.FuncContext.SetEvent(name, in)
@@ -109,7 +109,7 @@ func (r *Runtime) RegisterOpenFunction(
 					})
 				case ofctx.OpenFuncTopic:
 					sub := &dapr.Subscription{
-						PubsubName: input.Component,
+						PubsubName: input.ComponentName,
 						Topic:      input.Uri,
 					}
 					funcErr = r.handler.AddTopicEventHandler(sub, func(c context.Context, e *dapr.TopicEvent) (retry bool, err error) {
@@ -137,7 +137,7 @@ func (r *Runtime) RegisterOpenFunction(
 						}
 					})
 				default:
-					return fmt.Errorf("invalid input type: %s", input.Type)
+					return fmt.Errorf("invalid input type: %s", input.GetType())
 				}
 				if funcErr != nil {
 					// When the function throws an exception,


### PR DESCRIPTION
- `Component` -> `ComponentName`, which indicates the name of the component.
- add `ComponentType`, which indicates the type of the component.
- remote `Type`, as it is already included in `ComponentType`.

Signed-off-by: laminar <fangtian@kubesphere.io>