### PR TITLE
Set the exit span before sending the payload to the target.

### DIFF
--- a/plugin/skywalking/test/binding-event/expected.data.yml
+++ b/plugin/skywalking/test/binding-event/expected.data.yml
@@ -7,7 +7,7 @@ segmentItems:
   - segmentId: {{ notEmpty .segmentId }}
     spans:
     {{- contains .spans }}
-    - operationName: sample-topic
+    - operationName: provider
       parentSpanId: 0
       spanId: 1
       spanLayer: FAAS

--- a/plugin/skywalking/test/binding-event/provider/provider.go
+++ b/plugin/skywalking/test/binding-event/provider/provider.go
@@ -4,36 +4,17 @@ import (
 	"context"
 	"time"
 
+	"k8s.io/klog/v2"
+
 	ofctx "github.com/OpenFunction/functions-framework-go/context"
 	"github.com/OpenFunction/functions-framework-go/framework"
 	"github.com/OpenFunction/functions-framework-go/plugin"
 	"github.com/OpenFunction/functions-framework-go/plugin/skywalking"
-	"github.com/SkyAPM/go2sky"
-	"k8s.io/klog/v2"
-	agentv3 "skywalking.apache.org/repo/goapi/collect/language/agent/v3"
 )
 
 func bindingsFunction(ofCtx ofctx.Context, in []byte) (ofctx.Out, error) {
-	tracer := go2sky.GetGlobalTracer()
-	if tracer == nil {
-		klog.Warning("go2sky is not enabled")
-		return ofCtx.ReturnOnInternalError().WithData([]byte("go2sky is not enabled")), nil
-	}
 
-	span, err := tracer.CreateExitSpan(ofCtx.GetNativeContext(), "sample-topic", "sample-topic", func(headerKey, headerValue string) error {
-		ofCtx.GetInnerEvent().SetMetadata(headerKey, headerValue)
-		return nil
-	})
-	if err != nil {
-		klog.Error(err)
-		return ofCtx.ReturnOnInternalError().WithData([]byte(err.Error())), err
-	}
-	defer span.End()
-
-	span.SetSpanLayer(agentv3.SpanLayer_FAAS)
-	span.SetComponent(5013)
-
-	_, err = ofCtx.Send("sample-topic", []byte(time.Now().String()))
+	_, err := ofCtx.Send("sample-topic", []byte(time.Now().String()))
 	if err != nil {
 		klog.Error(err)
 		return ofCtx.ReturnOnInternalError().WithData([]byte(err.Error())), err

--- a/plugin/skywalking/test/topic-event/expected.data.yml
+++ b/plugin/skywalking/test/topic-event/expected.data.yml
@@ -7,7 +7,7 @@ segmentItems:
   - segmentId: {{ notEmpty .segmentId }}
     spans:
     {{- contains .spans }}
-    - operationName: publish-topic
+    - operationName: publish
       parentSpanId: 0
       spanId: 1
       spanLayer: FAAS

--- a/plugin/skywalking/test/topic-event/publish/publish.go
+++ b/plugin/skywalking/test/topic-event/publish/publish.go
@@ -4,37 +4,18 @@ import (
 	"context"
 	"time"
 
+	"k8s.io/klog/v2"
+
 	ofctx "github.com/OpenFunction/functions-framework-go/context"
 	"github.com/OpenFunction/functions-framework-go/framework"
 	"github.com/OpenFunction/functions-framework-go/plugin"
 	"github.com/OpenFunction/functions-framework-go/plugin/skywalking"
-	"github.com/SkyAPM/go2sky"
-	"k8s.io/klog/v2"
-	agentv3 "skywalking.apache.org/repo/goapi/collect/language/agent/v3"
 )
 
 func pubsubFunction(ofCtx ofctx.Context, in []byte) (ofctx.Out, error) {
-	tracer := go2sky.GetGlobalTracer()
-	if tracer == nil {
-		klog.Warningf("go2sky is not enabled")
-		return ofCtx.ReturnOnInternalError().WithData([]byte("go2sky is not enabled")), nil
-	}
-
-	span, err := tracer.CreateExitSpan(ofCtx.GetNativeContext(), "publish-topic", "publish-topic", func(headerKey, headerValue string) error {
-		ofCtx.GetInnerEvent().SetMetadata(headerKey, headerValue)
-		return nil
-	})
-	if err != nil {
-		klog.Error(err)
-		return ofCtx.ReturnOnInternalError().WithData([]byte(err.Error())), err
-	}
-	defer span.End()
-
-	span.SetSpanLayer(agentv3.SpanLayer_FAAS)
-	span.SetComponent(5013)
 
 	// topic
-	_, err = ofCtx.Send("publish-topic", []byte(time.Now().String()))
+	_, err := ofCtx.Send("publish-topic", []byte(time.Now().String()))
 
 	if err != nil {
 		klog.Error(err)


### PR DESCRIPTION
To complete the tracing of the full chain of events, we need to set the _**exit span**_ before the event is sent.

This measure only applies to middleware components that can deliver tracing information.

Signed-off-by: laminar <fangtian@kubesphere.io>