### PR TITLE
[Plugin-SkyWalking] Report pod name and namespace

### DIFF
--- a/plugin/skywalking/plugin-skywalking.go
+++ b/plugin/skywalking/plugin-skywalking.go
@@ -57,7 +57,10 @@ func (k klogWrapper) Errorf(format string, args ...interface{}) {
 
 func initGo2sky(ofCtx ofctx.RuntimeContext, p *PluginSkywalking) {
 	initGo2skyOnce.Do(func() {
-		r, err := reporter.NewGRPCReporter(ofCtx.GetPluginsTracingCfg().ProviderOapServer(), reporter.WithFAASLayer(), reporter.WithLog(&klogWrapper{}))
+		instanceProps := make(map[string]string)
+		instanceProps["pod"] = ofCtx.GetPodName()
+		instanceProps["namespace"] = ofCtx.GetPodNamespace()
+		r, err := reporter.NewGRPCReporter(ofCtx.GetPluginsTracingCfg().ProviderOapServer(), reporter.WithFAASLayer(), reporter.WithInstanceProps(instanceProps), reporter.WithLog(&klogWrapper{}))
 		if err != nil {
 			klog.Errorf("new go2sky grpc reporter error\n", err)
 			return


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/26432832/172390825-3a5c49d7-bad1-4a44-85be-7523b93520f7.png)

`podName` and namespace are reported and used in [on-demand-pod-log](https://skywalking.apache.org/docs/main/latest/en/setup/backend/on-demand-pod-log/).

@wu-sheng FYI :)