### PR TITLE
update cloud event input data to json format

### DIFF
--- a/test/declarative/sync-http-variables/verify-cloudevent-binary.sh
+++ b/test/declarative/sync-http-variables/verify-cloudevent-binary.sh
@@ -2,7 +2,7 @@
 
 url=http://$1
 while true; do
-  st=$(curl -s -o /dev/null -w "%{http_code}" "$url" -H "Ce-Specversion: 1.0" -H "Ce-Type: io.openfunction.samples.helloworld" -H "Ce-Source: io.openfunction.samples/helloworldsource" -H "Ce-Id: 536808d3-88be-4077-9d7a-a3f162705f79" -H "Content-Type: application/json" -d 'hello')
+  st=$(curl -s -o /dev/null -w "%{http_code}" "$url" -H "Ce-Specversion: 1.0" -H "Ce-Type: io.openfunction.samples.helloworld" -H "Ce-Source: io.openfunction.samples/helloworldsource" -H "Ce-Id: 536808d3-88be-4077-9d7a-a3f162705f79" -H "Content-Type: application/json" -d '{"data":"hello"}')
   if [ "$st" -eq 200 ]; then
     data_result=$(KUBECONFIG=/tmp/e2e-k8s.config kubectl logs --tail=2 -l app="sync-http-variables" -c http | grep Data | awk '{ print $8 }' | yq -P '.' -)
     plugin_result=$(KUBECONFIG=/tmp/e2e-k8s.config kubectl logs --tail=2 -l app="sync-http-variables" -c http | grep plugin | awk '{ print $8 }' | yq -P '.' -)

--- a/test/declarative/sync-http-variables/verify-cloudevent-structured.sh
+++ b/test/declarative/sync-http-variables/verify-cloudevent-structured.sh
@@ -2,7 +2,7 @@
 
 url=http://$1
 while true; do
-  st=$(curl -s -o /dev/null -w "%{http_code}" "$url" -H "Content-Type: application/json" -d '{"specversion" : "1.0", "type" : "example.com.cloud.event", "source" : "https://example.com/cloudevents/pull", "subject" : "123", "id" : "A234-1234-1234", "time" : "2018-04-05T17:31:00Z", "data" : "hello"}')
+  st=$(curl -s -o /dev/null -w "%{http_code}" "$url" -H "Content-Type: application/cloudevents+json" -d '{"specversion":"1.0","type":"dev.knative.samples.helloworld","source":"dev.knative.samples/helloworldsource","id":"536808d3-88be-4077-9d7a-a3f162705f79","data":{"data":"hello"}}')
   if [ "$st" -eq 200 ]; then
     data_result=$(KUBECONFIG=/tmp/e2e-k8s.config kubectl logs --tail=2 -l app="sync-http-variables" -c http | grep Data | awk '{ print $8 }' | yq -P '.' -)
     plugin_result=$(KUBECONFIG=/tmp/e2e-k8s.config kubectl logs --tail=2 -l app="sync-http-variables" -c http | grep plugin | awk '{ print $8 }' | yq -P '.' -)

--- a/test/declarative/sync-http-variables/verify-ofn-cloudevent-binary.sh
+++ b/test/declarative/sync-http-variables/verify-ofn-cloudevent-binary.sh
@@ -2,9 +2,9 @@
 
 url=http://$1
 while true; do
-  st=$(curl -s -o /dev/null -w "%{http_code}" "$url" -H "Ce-Specversion: 1.0" -H "Ce-Type: io.openfunction.samples.helloworld" -H "Ce-Source: io.openfunction.samples/helloworldsource" -H "Ce-Id: 536808d3-88be-4077-9d7a-a3f162705f79" -H "Content-Type: application/json" -d 'hello')
+  st=$(curl -s -o /dev/null -w "%{http_code}" "$url" -H "Ce-Specversion: 1.0" -H "Ce-Type: io.openfunction.samples.helloworld" -H "Ce-Source: io.openfunction.samples/helloworldsource" -H "Ce-Id: 536808d3-88be-4077-9d7a-a3f162705f79" -H "Content-Type: application/json" -d '{"data":"hello"}')
   if [ "$st" -eq 200 ]; then
-    data_result=$(curl -X POST -H "Content-type: application/json" -H "Accept: application/json" -s "$url" -H "Ce-Specversion: 1.0" -H "Ce-Type: io.openfunction.samples.helloworld" -H "Ce-Source: io.openfunction.samples/helloworldsource" -H "Ce-Id: 536808d3-88be-4077-9d7a-a3f162705f79" -H "Content-Type: application/json" -d 'hello' | yq -P ".")
+    data_result=$(curl -X POST -H "Content-type: application/json" -H "Accept: application/json" -s "$url" -H "Ce-Specversion: 1.0" -H "Ce-Type: io.openfunction.samples.helloworld" -H "Ce-Source: io.openfunction.samples/helloworldsource" -H "Ce-Id: 536808d3-88be-4077-9d7a-a3f162705f79" -H "Content-Type: application/json" -d '{"data":"hello"}' | yq -P ".")
     plugin_result=$(KUBECONFIG=/tmp/e2e-k8s.config kubectl logs --tail=1 -l app="sync-http-variables" -c http | grep plugin | awk '{ print $8 }' | yq -P '.' -)
     break
   else

--- a/test/declarative/sync-http-variables/verify-ofn-cloudevent-structured.sh
+++ b/test/declarative/sync-http-variables/verify-ofn-cloudevent-structured.sh
@@ -2,9 +2,9 @@
 
 url=http://$1
 while true; do
-  st=$(curl -s -o /dev/null -w "%{http_code}" "$url" -H "Content-Type: application/json" -d '{"specversion" : "1.0", "type" : "example.com.cloud.event", "source" : "https://example.com/cloudevents/pull", "subject" : "123", "id" : "A234-1234-1234", "time" : "2018-04-05T17:31:00Z", "data" : "hello"}')
+  st=$(curl -s -o /dev/null -w "%{http_code}" "$url" -H "Content-Type: application/cloudevents+json" -d '{"specversion":"1.0","type":"dev.knative.samples.helloworld","source":"dev.knative.samples/helloworldsource","id":"536808d3-88be-4077-9d7a-a3f162705f79","data":{"data":"hello"}}')
   if [ "$st" -eq 200 ]; then
-    data_result=$(curl -X POST -H "Content-Type: application/json" -d '{"specversion" : "1.0", "type" : "example.com.cloud.event", "source" : "https://example.com/cloudevents/pull", "subject" : "123", "id" : "A234-1234-1234", "time" : "2018-04-05T17:31:00Z", "data" : "hello"}' | yq -P ".")
+    data_result=$(curl -X POST -H "Content-Type: application/cloudevents+json" -H "Accept: application/json" -s "$url" -d '{"specversion":"1.0","type":"dev.knative.samples.helloworld","source":"dev.knative.samples/helloworldsource","id":"536808d3-88be-4077-9d7a-a3f162705f79","data":{"data":"hello"}}' | yq -P ".")
     plugin_result=$(KUBECONFIG=/tmp/e2e-k8s.config kubectl logs --tail=1 -l app="sync-http-variables" -c http | grep plugin | awk '{ print $8 }' | yq -P '.' -)
     break
   else

--- a/test/declarative/sync-http-variables/verify-ofn-http.sh
+++ b/test/declarative/sync-http-variables/verify-ofn-http.sh
@@ -2,9 +2,9 @@
 
 url=http://$1
 while true; do
-  st=$(curl -s -o /dev/null -w "%{http_code}" -X GET "$url")
+  st=$(curl -s -o /dev/null -w "%{http_code}" -X GET "$url" -d '{"data":"hello"}')
   if [ "$st" -eq 200 ]; then
-    data_result=$(curl -X POST -H "Content-type: application/json" -H "Accept: application/json" -s "$url" -d 'hello' | yq -P ".")
+    data_result=$(curl -X POST -H "Content-type: application/json" -H "Accept: application/json" -s "$url" -d '{"data":"hello"}' | yq -P ".")
     plugin_result=$(KUBECONFIG=/tmp/e2e-k8s.config kubectl logs --tail=1 -l app="sync-http-variables" -c http | awk '{ print $8 }' | yq -P '.' -)
     break
   else


### PR DESCRIPTION
followup PR of https://github.com/OpenFunction/functions-framework-go/pull/52 to fix the tests for binary and structured cloud event format. 

For cloud event input, data prefer to be in JSON format and unmarshal it in the user code, so that the result will be consistent for both binary and structured format.

binary format:
```
❯ curl -X POST "http://localhost:8080/bar/openfunction" \
  -H "Ce-Specversion: 1.0" \
  -H "Ce-Type: dev.knative.samples.helloworld" \
  -H "Ce-Source: dev.knative.samples/helloworldsource" \
  -H "Ce-Subject: 123" \
  -H "Ce-Id: 536808d3-88be-4077-9d7a-a3f162705f79" \
  -H "Content-Type: application/json" \
  -d 'hello'
{"hello":"openfunction"}%
```

structured format:
```
❯ curl -X POST "http://localhost:8080/bar/openfunction" \
   -H "Content-Type: application/cloudevents+json" \
   -d '{"specversion":"1.0","type":"dev.knative.samples.helloworld","source":"dev.knative.samples/helloworldsource","id":"536808d3-88be-4077-9d7a-a3f162705f79","data":"hello"}'
{"\"hello\"":"openfunction"}% 
```
> you can see there are `\"` in the data. 