### PR TITLE
switch from gorilla/mux to go-chi

### DIFF
--- a/context/context_test.go
+++ b/context/context_test.go
@@ -1,11 +1,11 @@
 package context
 
 import (
+	"net/http"
 	"os"
+	"reflect"
 	"strings"
 	"testing"
-	"net/http"
-	"reflect"
 )
 
 var (
@@ -108,8 +108,8 @@ var (
 // TestParseFunctionContext tests and verifies the function that parses the function FunctionContext
 func TestParseFunctionContext(t *testing.T) {
 	_, err := GetRuntimeContext()
-	if !strings.Contains(err.Error(), "env FUNC_CONTEXT not found") {
-		t.Fatal("Error parse function context")
+	if err != nil && !strings.Contains(err.Error(), "env FUNC_CONTEXT not found") {
+		t.Fatalf("Error parse function context: %s", err.Error())
 	}
 
 	// test `podName`, `podNamespace` field
@@ -295,7 +295,6 @@ func TestParseFunctionContext(t *testing.T) {
 	}
 }
 
-
 func TestGetVarsFromContext(t *testing.T) {
 
 	tests := []struct {
@@ -304,14 +303,14 @@ func TestGetVarsFromContext(t *testing.T) {
 		vars    map[string]string
 	}{
 		{
-			name: "single variable",
+			name:    "single variable",
 			request: &http.Request{},
-			vars: map[string]string{"key1": "val1"},
+			vars:    map[string]string{"key1": "val1"},
 		},
 		{
-			name: "multi variables",
+			name:    "multi variables",
 			request: &http.Request{},
-			vars: map[string]string{"key1": "val1", "key2": "val2"},
+			vars:    map[string]string{"key1": "val1", "key2": "val2"},
 		},
 	}
 	for _, tt := range tests {

--- a/go.mod
+++ b/go.mod
@@ -8,9 +8,9 @@ require (
 	github.com/dapr/dapr v1.8.3
 	github.com/dapr/go-sdk v1.5.0
 	github.com/fatih/structs v1.1.0
+	github.com/go-chi/chi/v5 v5.0.8
 	github.com/golang/protobuf v1.5.2
 	github.com/google/uuid v1.3.0
-	github.com/gorilla/mux v1.8.0
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.7.4
 	google.golang.org/grpc v1.47.0
@@ -21,6 +21,7 @@ require (
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/go-logr/logr v1.2.3 // indirect
+	github.com/gorilla/mux v1.8.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/kr/pretty v0.3.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect

--- a/go.sum
+++ b/go.sum
@@ -646,8 +646,11 @@ github.com/gin-contrib/sse v0.1.0/go.mod h1:RHrZQHXnP2xjPF+u1gW/2HnVO7nvIa9PG3Gm
 github.com/gin-gonic/gin v1.6.3/go.mod h1:75u5sXoLsGZoRN5Sgbi1eraJ4GU3++wFwWzhwvtwp4M=
 github.com/gin-gonic/gin v1.7.7/go.mod h1:axIBovoeJpVj8S3BwE0uPMTeReE4+AfFtqpqaZ1qq1U=
 github.com/go-asn1-ber/asn1-ber v1.3.1/go.mod h1:hEBeB/ic+5LoWskz+yKT7vGhhPYkProFKoKdwZRWMe0=
+github.com/go-chi/chi v4.0.2+incompatible h1:maB6vn6FqCxrpz4FqWdh4+lwpyZIQS7YEAUcHlgXVRs=
 github.com/go-chi/chi v4.0.2+incompatible/go.mod h1:eB3wogJHnLi3x/kFX2A+IbTBlXxmMeXJVKy9tTv1XzQ=
 github.com/go-chi/chi/v5 v5.0.0/go.mod h1:BBug9lr0cqtdAhsu6R4AAdvufI0/XBzAQSsUqJpoZOs=
+github.com/go-chi/chi/v5 v5.0.8 h1:lD+NLqFcAi1ovnVZpsnObHGW4xb4J8lNmoYVfECH1Y0=
+github.com/go-chi/chi/v5 v5.0.8/go.mod h1:DslCQbL2OYiznFReuXYUmQ2hGd1aDpCnlMNITLSKoi8=
 github.com/go-co-op/gocron v1.9.0/go.mod h1:DbJm9kdgr1sEvWpHCA7dFFs/PGHPMil9/97EXCRPr4k=
 github.com/go-errors/errors v1.0.1/go.mod h1:f4zRHt4oKfwPJE5k8C9vpYG+aDHdBFUsgrm6/TyX73Q=
 github.com/go-errors/errors v1.4.0/go.mod h1:sIVyrIiJhuEF+Pj9Ebtd6P/rEYROXFi3BopGUQ5a5Og=

--- a/test/bindings/e2e.yaml
+++ b/test/bindings/e2e.yaml
@@ -35,6 +35,14 @@ setup:
       path: manifests.yaml
       wait:
         - namespace: default
+          resource: deployments
+          label-selector: app=bindings-sender
+          for: condition=Available
+        - namespace: default
+          resource: deployments
+          label-selector: app=bindings-target
+          for: condition=Available
+        - namespace: default
           resource: pod
           label-selector: app=bindings-sender
           for: condition=Ready

--- a/test/bindings/e2e.yaml
+++ b/test/bindings/e2e.yaml
@@ -19,7 +19,7 @@ setup:
     - name: install kafka operator
       command: |
         helm repo add strimzi https://strimzi.io/charts/
-        helm install kafka-operator -n default strimzi/strimzi-kafka-operator
+        helm install kafka-operator -n default strimzi/strimzi-kafka-operator --version 0.35.0
 
     - name: install kafka
       path: ../kafka.yaml

--- a/test/declarative/sync-http-variables/README.md
+++ b/test/declarative/sync-http-variables/README.md
@@ -1,0 +1,72 @@
+# Sync-HTTP-Variables
+
+To run test cases locally
+
+## Run locally
+
+```sh
+$ cd test/declarative/sync-http-variables
+$ go run main.go http.go
+```
+
+## Send request
+
+### HTTP
+
+```sh
+$ curl -X POST "http://localhost:8080/hello/openfunction?key1=value1" -d 'hello'
+
+{"hello":"openfunction"}% 
+```
+
+### CloudEvent
+
+```sh
+# binary
+$ curl "http://localhost:8080/foo/openfunction" \
+    -H "Ce-Specversion: 1.0" \
+    -H "Ce-Type: io.openfunction.samples.helloworld" \
+    -H "Ce-Source: io.openfunction.samples/helloworldsource" \
+    -H "Ce-Id: 536808d3-88be-4077-9d7a-a3f162705f79" \
+    -H "Content-Type: application/json" \
+    -d '{"data":"hello"}'
+
+I0605 01:38:57.481196   81001 http.go:87] cloudevent - Data: {"hello":"openfunction"}
+I0605 01:38:57.481310   81001 plugin-example.go:88] plugin - Result: {"sum":2}
+
+# structured
+$ curl "http://localhost:8080/foo/openfunction" \
+    -H "Content-Type: application/cloudevents+json" \
+    -d '{"specversion":"1.0","type":"io.openfunction.samples.helloworld","source":"io.openfunction.samples/helloworldsource","id":"536808d3-88be-4077-9d7a-a3f162705f79","data":{"data":"hello"}}'
+
+I0605 01:46:52.336317   81001 http.go:87] cloudevent - Data: {"hello":"openfunction"}
+I0605 01:46:52.336342   81001 plugin-example.go:88] plugin - Result: {"sum":2}
+```
+
+### OpenFunction
+
+```sh
+# HTTP
+$ curl -X GET "http://localhost:8080/bar/openfunction?key1=value1" -d '{"data":"hello"}'
+
+{"hello":"openfunction"}%
+
+# CloudEvent
+## binary
+$ curl "http://localhost:8080/bar/openfunction" \
+    -H "Ce-Specversion: 1.0" \
+    -H "Ce-Type: io.openfunction.samples.helloworld" \
+    -H "Ce-Source: io.openfunction.samples/helloworldsource" \
+    -H "Ce-Id: 536808d3-88be-4077-9d7a-a3f162705f79" \
+    -H "Content-Type: application/json" \
+    -d '{"data":"hello"}'
+
+{"hello":"openfunction"}
+
+## structured
+$ curl "http://localhost:8080/bar/openfunction" \
+    -H "Content-Type: application/cloudevents+json" \
+    -d '{"specversion":"1.0","type":"io.openfunction.samples.helloworld","source":"io.openfunction.samples/helloworldsource","id":"536808d3-88be-4077-9d7a-a3f162705f79","data":{"data":"hello"}}'
+
+{"hello":"openfunction"}%
+```

--- a/test/declarative/sync-http-variables/http.go
+++ b/test/declarative/sync-http-variables/http.go
@@ -46,9 +46,9 @@ type Message struct {
 }
 
 func hello(w http.ResponseWriter, r *http.Request) {
-	vars := ofctx.VarsFromCtx(r.Context())
+	name := ofctx.URLParamFromCtx(r.Context(), "name")
 	response := map[string]string{
-		"hello": vars["name"],
+		"hello": name,
 	}
 	responseBytes, _ := json.Marshal(response)
 	w.Header().Set("Content-type", "application/json")
@@ -56,6 +56,8 @@ func hello(w http.ResponseWriter, r *http.Request) {
 }
 
 func hellov2(w http.ResponseWriter, r *http.Request) {
+	// keep for backward compatibility, same for example below
+	// suggest to use ofctx.URLParamFromCtx(...) to get vars
 	vars := ofctx.VarsFromCtx(r.Context())
 	response := map[string]string{
 		"hello": vars["name"],
@@ -66,16 +68,15 @@ func hellov2(w http.ResponseWriter, r *http.Request) {
 }
 
 func foo(ctx context.Context, ce cloudevents.Event) error {
-	vars := ofctx.VarsFromCtx(ctx)
-
 	msg := &Message{}
 	err := json.Unmarshal(ce.Data(), msg)
 	if err != nil {
 		return err
 	}
 
+	name := ofctx.URLParamFromCtx(ctx, "name")
 	response := map[string]string{
-		msg.Data: vars["name"],
+		msg.Data: name,
 	}
 	responseBytes, _ := json.Marshal(response)
 	klog.Infof("cloudevent - Data: %s", string(responseBytes))
@@ -100,15 +101,15 @@ func foov2(ctx context.Context, ce cloudevents.Event) error {
 }
 
 func bar(ctx ofctx.Context, in []byte) (ofctx.Out, error) {
-	vars := ofctx.VarsFromCtx(ctx.GetNativeContext())
 	msg := &Message{}
 	err := json.Unmarshal(in, msg)
 	if err != nil {
 		return ctx.ReturnOnInternalError(), err
 	}
 
+	name := ofctx.URLParamFromCtx(ctx.GetNativeContext(), "name")
 	response := map[string]string{
-		msg.Data: vars["name"],
+		msg.Data: name,
 	}
 	responseBytes, _ := json.Marshal(response)
 	return ctx.ReturnOnSuccess().WithData(responseBytes), nil

--- a/test/declarative/sync-http-variables/verify-cloudevent-structured.sh
+++ b/test/declarative/sync-http-variables/verify-cloudevent-structured.sh
@@ -2,7 +2,7 @@
 
 url=http://$1
 while true; do
-  st=$(curl -s -o /dev/null -w "%{http_code}" "$url" -H "Content-Type: application/cloudevents+json" -d '{"specversion":"1.0","type":"dev.knative.samples.helloworld","source":"dev.knative.samples/helloworldsource","id":"536808d3-88be-4077-9d7a-a3f162705f79","data":{"data":"hello"}}')
+  st=$(curl -s -o /dev/null -w "%{http_code}" "$url" -H "Content-Type: application/cloudevents+json" -d '{"specversion":"1.0","type":"io.openfunction.samples.helloworld","source":"io.openfunction.samples/helloworldsource","id":"536808d3-88be-4077-9d7a-a3f162705f79","data":{"data":"hello"}}')
   if [ "$st" -eq 200 ]; then
     data_result=$(KUBECONFIG=/tmp/e2e-k8s.config kubectl logs --tail=2 -l app="sync-http-variables" -c http | grep Data | awk '{ print $8 }' | yq -P '.' -)
     plugin_result=$(KUBECONFIG=/tmp/e2e-k8s.config kubectl logs --tail=2 -l app="sync-http-variables" -c http | grep plugin | awk '{ print $8 }' | yq -P '.' -)

--- a/test/kafka.yaml
+++ b/test/kafka.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: default
 spec:
   kafka:
-    version: 3.1.0
+    version: 3.4.0
     replicas: 1
     listeners:
       - name: plain
@@ -22,7 +22,7 @@ spec:
       transaction.state.log.min.isr: 1
       default.replication.factor: 1
       min.insync.replicas: 1
-      inter.broker.protocol.version: "3.1"
+      inter.broker.protocol.version: "3.4"
     storage:
       type: ephemeral
   zookeeper:

--- a/test/pubsub/e2e.yaml
+++ b/test/pubsub/e2e.yaml
@@ -19,7 +19,7 @@ setup:
     - name: install kafka operator
       command: |
         helm repo add strimzi https://strimzi.io/charts/
-        helm install kafka-operator -n default strimzi/strimzi-kafka-operator
+        helm install kafka-operator -n default strimzi/strimzi-kafka-operator --version 0.35.0
 
     - name: install kafka
       path: ../kafka.yaml

--- a/test/pubsub/e2e.yaml
+++ b/test/pubsub/e2e.yaml
@@ -35,6 +35,14 @@ setup:
       path: manifests.yaml
       wait:
         - namespace: default
+          resource: deployments
+          label-selector: app=pubsub-subscriber
+          for: condition=Available
+        - namespace: default
+          resource: deployments
+          label-selector: app=pubsub-publisher
+          for: condition=Available
+        - namespace: default
           resource: pod
           label-selector: app=pubsub-subscriber
           for: condition=Ready

--- a/test/sync-http/e2e.yaml
+++ b/test/sync-http/e2e.yaml
@@ -11,6 +11,10 @@ setup:
       path: manifests.yaml
       wait:
         - namespace: default
+          resource: deployments
+          label-selector: app=sync-http
+          for: condition=Available
+        - namespace: default
           resource: pod
           label-selector: app=sync-http
           for: condition=Ready


### PR DESCRIPTION
fix: #68 

This PR switched from `gorilla/mux` to `go-chi`.

Note:

1. The new way to read path variables is using `ofctx.URLParamFromCtx(...)`, example:
```go
name := ofctx.URLParamFromCtx(r.Context(), "name")
```
However, the previous method: `vars := ofctx.VarsFromCtx(r.Context())` is kept for backward compatibility.

2. `gorilla/mux` is still in the `go.mod` as current `go-sdk` is using it. Will be removed in [go-sdk v1.8](https://github.com/dapr/go-sdk/pull/357).